### PR TITLE
Remove redirect from / to /index

### DIFF
--- a/app.py
+++ b/app.py
@@ -3,10 +3,6 @@ from flask import Flask, render_template, request, redirect
 app = Flask(__name__)
 
 @app.route('/')
-def main():
-  return redirect('/index')
-
-@app.route('/index')
 def index():
   return render_template('index.html')
 


### PR DESCRIPTION
Unless I'm missing something, there's no reason for this redirect.  It makes more sense to just serve the content at /.  Every single student flask website I've seen has had this redirect in it, so students are getting the impression that this is important.

The downsides of removing it is that we no longer have examples of:
1. redirects.  But there are more important thinks about Flask that we're not covering.
2. serving multiple endpoints.  If we think students won't be able to generalize from a single example, we should add a better example than a redirect.